### PR TITLE
fix(ci): unblock release workflow tests under self-contained WinApp SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,18 @@ jobs:
         run: dotnet restore VoxScript.slnx
 
       - name: Test (release gate)
-        run: dotnet test VoxScript.Tests --configuration Release --no-restore
+        # -r win-x64 triggers the RID-conditional WindowsAppSDKSelfContained
+        # property on VoxScript.Tests.csproj so the test host doesn't hang
+        # looking for a system-installed WinApp SDK runtime on the runner.
+        # --blame-hang-timeout fails the run in 5 min instead of silently
+        # hanging the whole workflow if a test deadlocks.
+        run: >
+          dotnet test VoxScript.Tests
+          --configuration Release
+          --no-restore
+          -r win-x64
+          --blame-hang-timeout 5min
+          --logger "console;verbosity=normal"
 
       - name: Publish
         run: >

--- a/VoxScript.Tests/VoxScript.Tests.csproj
+++ b/VoxScript.Tests/VoxScript.Tests.csproj
@@ -8,6 +8,14 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- When invoked with a RID (e.g. `dotnet test -r win-x64` in CI), bundle the
+       WinApp SDK into the test output so the test host doesn't hang looking
+       for a system-installed WindowsAppSDK runtime that CI runners don't have.
+       Inner-loop `dotnet test` with no RID skips this and stays fast. -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />

--- a/VoxScript/Onboarding/Steps/TryItStepViewModel.cs
+++ b/VoxScript/Onboarding/Steps/TryItStepViewModel.cs
@@ -41,7 +41,11 @@ public sealed partial class TryItStepViewModel : ObservableObject, IDisposable
         // VoxScriptEngine fires TranscriptionCompleted on whatever thread the pipeline
         // resolved on — setting [ObservableProperty] values from those threads would
         // raise PropertyChanged synchronously and crash when the bound UI tries to update.
-        _dispatcher = DispatcherQueue.GetForCurrentThread();
+        // Under self-contained WinAppSDK (used for CI test runs with `-r win-x64`),
+        // this call throws COMException on threads without a registered dispatcher;
+        // fall through to null and let RunOnUi invoke actions directly.
+        try { _dispatcher = DispatcherQueue.GetForCurrentThread(); }
+        catch (System.Runtime.InteropServices.COMException) { _dispatcher = null; }
         SubState = TryItSubState.Idle;
         TranscriptText = string.Empty;
 


### PR DESCRIPTION
The release workflow hung at `dotnet test` because GitHub's fresh windows-latest runners don't have the WindowsAppSDK runtime installed; the test host was deadlocking when loading WinUI-dependent test assemblies rather than failing cleanly.

- VoxScript.Tests.csproj: RID-conditional WindowsAppSDKSelfContained so `dotnet test -r win-x64` bundles the runtime into the test build. Inner-loop `dotnet test` without RID keeps the fast path.
- VoxScript/Onboarding/Steps/TryItStepViewModel.cs: DispatcherQueue .GetForCurrentThread() throws COMException under self-contained WinAppSDK (returns null in framework-dependent mode). Defensive catch falls through to null; existing RunOnUi null-guard handles the rest.
- .github/workflows/release.yml: pass -r win-x64 + --blame-hang-timeout 5min + verbose logger. Future hangs now fail with a crash dump in 5 min instead of silently burning 30+ minutes.

Verified: 325/325 tests pass in both modes (inner-loop no-RID ~0.8s, CI-equivalent -r win-x64 ~1.4s).