### PR TITLE
fix(ci): declare win-x64 RID on VoxScript.Tests so restore picks it up

### DIFF
--- a/VoxScript.Tests/VoxScript.Tests.csproj
+++ b/VoxScript.Tests/VoxScript.Tests.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <!-- Declared so `dotnet restore` resolves win-x64 assets for the CI
+         `dotnet test -r win-x64` path; no effect on inner-loop test runs. -->
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Previous fix (f689fca/667a731) wired the workflow's test step to pass -r win-x64 with --no-restore, but the solution-level `dotnet restore VoxScript.slnx` didn't produce win-x64 assets for VoxScript.Tests because the test project declares no RuntimeIdentifiers. Result: test step failed with NETSDK1047 'Assets file doesn't have a target for net10.0-windows10.0.19041.0/win-x64'.

Adding <RuntimeIdentifiers>win-x64</RuntimeIdentifiers> (plural, for restore-time RID resolution only) lets the solution-level restore include win-x64 assets. Inner-loop `dotnet test` without -r still builds framework-dependent as before.

Verified CI-equivalent: dotnet restore VoxScript.slnx && dotnet test VoxScript.Tests -r win-x64 --no-restore passes 325/325 in ~1.6s.