### PR TITLE
Drop WAV retention after transcription

### DIFF
--- a/VoxScript.Core/Migrations/20260419075629_DropAudioFilePath.Designer.cs
+++ b/VoxScript.Core/Migrations/20260419075629_DropAudioFilePath.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VoxScript.Core.Persistence;
 
@@ -10,9 +11,11 @@ using VoxScript.Core.Persistence;
 namespace VoxScript.Core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419075629_DropAudioFilePath")]
+    partial class DropAudioFilePath
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/VoxScript.Core/Migrations/20260419075629_DropAudioFilePath.cs
+++ b/VoxScript.Core/Migrations/20260419075629_DropAudioFilePath.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VoxScript.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropAudioFilePath : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AudioFilePath",
+                table: "Transcriptions");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AudioFilePath",
+                table: "Transcriptions",
+                type: "TEXT",
+                nullable: true);
+        }
+    }
+}

--- a/VoxScript.Core/Persistence/TranscriptionRecord.cs
+++ b/VoxScript.Core/Persistence/TranscriptionRecord.cs
@@ -9,7 +9,6 @@ public sealed class TranscriptionRecord
     public int Id { get; set; }
     [Required] public string Text { get; set; } = string.Empty;
     public string? EnhancedText { get; set; }
-    public string? AudioFilePath { get; set; }
     public double DurationSeconds { get; set; }
     public string? ModelName { get; set; }
     public string? Language { get; set; }

--- a/VoxScript.Core/Transcription/Core/TranscriptionPipeline.cs
+++ b/VoxScript.Core/Transcription/Core/TranscriptionPipeline.cs
@@ -180,7 +180,6 @@ public sealed class TranscriptionPipeline
                 {
                     Text = replaced,
                     EnhancedText = enhancedText,
-                    AudioFilePath = audioFilePath,
                     DurationSeconds = durationSeconds,
                     ModelName = session.Model.Name,
                     WasAiEnhanced = enhancedText is not null,

--- a/VoxScript.Core/Transcription/Core/VoiceInkEngine.cs
+++ b/VoxScript.Core/Transcription/Core/VoiceInkEngine.cs
@@ -207,6 +207,7 @@ public sealed partial class VoxScriptEngine : ObservableObject, IWizardEngine
         {
             Log.Debug("Dropping short recording: {Duration:0.00}s < {Threshold:0.00}s threshold",
                 duration, MinRecordingSeconds);
+            DeleteWavFile();
             _sounds.PlayCancel();
             if (_settings.PauseMediaWhileDictating)
                 await _media.ResumeMediaAsync();
@@ -304,6 +305,28 @@ public sealed partial class VoxScriptEngine : ObservableObject, IWizardEngine
         bw.Flush();
         _wavStream.Dispose();
         _wavStream = null;
+    }
+
+    /// <summary>
+    /// Deletes the WAV file recorded during the last session.
+    /// Safe to call when no file was written (streaming sessions or startup failures
+    /// before the WAV was opened): <see cref="_currentAudioPath"/> will be null.
+    /// </summary>
+    private void DeleteWavFile()
+    {
+        if (_currentAudioPath is null) return;
+        try
+        {
+            File.Delete(_currentAudioPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Log.Warning(ex, "Could not delete WAV file {Path}", _currentAudioPath);
+        }
+        finally
+        {
+            _currentAudioPath = null;
+        }
     }
 
     public async Task CancelRecordingAsync()

--- a/VoxScript.Core/Transcription/Core/VoiceInkEngine.cs
+++ b/VoxScript.Core/Transcription/Core/VoiceInkEngine.cs
@@ -345,6 +345,11 @@ public sealed partial class VoxScriptEngine : ObservableObject, IWizardEngine
 
         _cts?.Cancel();
         await _audio.StopAsync();
+        // Audio callbacks are stopped; safe to dispose the stream. We skip
+        // FinalizeWav() because we're deleting the file anyway.
+        _wavStream?.Dispose();
+        _wavStream = null;
+        DeleteWavFile();
         await (_activeSession?.CancelAsync() ?? Task.CompletedTask);
         _activeSession = null;
         State = RecordingState.Idle;
@@ -353,6 +358,7 @@ public sealed partial class VoxScriptEngine : ObservableObject, IWizardEngine
             await _media.ResumeMediaAsync();
         AudioLevel = 0f;
         _suppressAutoPaste = false;
+        _suppressPersist = false;
     }
 
     /// <summary>

--- a/VoxScript.Core/Transcription/Core/VoiceInkEngine.cs
+++ b/VoxScript.Core/Transcription/Core/VoiceInkEngine.cs
@@ -164,6 +164,7 @@ public sealed partial class VoxScriptEngine : ObservableObject, IWizardEngine
             await _audio.StopAsync();
             _wavStream?.Dispose();
             _wavStream = null;
+            DeleteWavFile();
             _activeSession = null;
             _cts?.Dispose();
             _cts = null;

--- a/VoxScript.Core/Transcription/Core/VoiceInkEngine.cs
+++ b/VoxScript.Core/Transcription/Core/VoiceInkEngine.cs
@@ -265,6 +265,7 @@ public sealed partial class VoxScriptEngine : ObservableObject, IWizardEngine
         }
         finally
         {
+            DeleteWavFile();
             _activeSession = null;
             _cts?.Dispose();
             _cts = null;

--- a/VoxScript.Tests/Transcription/VoxScriptEngineWavCleanupTests.cs
+++ b/VoxScript.Tests/Transcription/VoxScriptEngineWavCleanupTests.cs
@@ -1,0 +1,225 @@
+using FluentAssertions;
+using NSubstitute;
+using VoxScript.Core.Audio;
+using VoxScript.Core.Dictionary;
+using VoxScript.Core.Platform;
+using VoxScript.Core.PowerMode;
+using VoxScript.Core.Settings;
+using VoxScript.Core.Transcription.Core;
+using VoxScript.Core.Transcription.Models;
+using VoxScript.Core.Transcription.Processing;
+
+namespace VoxScript.Tests.Transcription;
+
+/// <summary>
+/// Verifies that <see cref="VoxScriptEngine"/> deletes the WAV file on every
+/// recording-lifecycle exit path: successful pipeline completion, pipeline
+/// failure, and the short-recording early-return branch.
+/// </summary>
+public class VoxScriptEngineWavCleanupTests : IDisposable
+{
+    private readonly string _recordingsDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "VoxScript", "Recordings");
+
+    // Paths the engine used during the test — tracked so Dispose can clean up
+    // leftover files if an assertion fails before the engine deletes them.
+    private readonly List<string> _touchedPaths = new();
+
+    // Files that existed in the Recordings directory before the test ran, so
+    // the short-recording test can diff before/after to detect leaked WAVs.
+    private readonly HashSet<string> _preExistingFiles;
+
+    public VoxScriptEngineWavCleanupTests()
+    {
+        Directory.CreateDirectory(_recordingsDir);
+        _preExistingFiles = Directory.GetFiles(_recordingsDir, "rec_*.wav").ToHashSet();
+    }
+
+    // ── Test: success path ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StopAndTranscribe_deletes_wav_after_successful_transcription()
+    {
+        var fakeService = new CapturingTranscriptionService { Result = "hello world" };
+        var engine = CreateEngine(fakeService);
+        var model = CreateLocalModel();
+
+        await engine.StartRecordingAsync(model);
+        await Task.Delay(600); // Clear 0.5s MinRecordingSeconds threshold.
+        await engine.StopAndTranscribeAsync();
+
+        fakeService.CapturedPath.Should().NotBeNull(
+            "engine must have reached the pipeline and invoked TranscribeAsync");
+        _touchedPaths.Add(fakeService.CapturedPath!);
+
+        File.Exists(fakeService.CapturedPath!).Should().BeFalse(
+            "engine must delete the WAV file after the pipeline completes");
+    }
+
+    // ── Test: failure path ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StopAndTranscribe_deletes_wav_when_pipeline_throws()
+    {
+        var fakeService = new CapturingTranscriptionService
+        {
+            Throw = () => throw new InvalidOperationException("transcription backend down"),
+        };
+        var engine = CreateEngine(fakeService);
+        var model = CreateLocalModel();
+
+        await engine.StartRecordingAsync(model);
+        await Task.Delay(600); // Clear short-recording gate so TranscribeAsync runs.
+
+        // Engine catches pipeline exceptions internally (see the try/catch in
+        // StopAndTranscribeAsync) — the test itself should not observe a throw.
+        await engine.StopAndTranscribeAsync();
+
+        fakeService.CapturedPath.Should().NotBeNull(
+            "TranscribeAsync must have been invoked and captured the path before throwing");
+        _touchedPaths.Add(fakeService.CapturedPath!);
+
+        File.Exists(fakeService.CapturedPath!).Should().BeFalse(
+            "engine must delete the WAV even when the pipeline throws");
+    }
+
+    // ── Test: short-recording path ────────────────────────────────────────
+
+    [Fact]
+    public async Task StopAndTranscribe_deletes_wav_on_short_recording()
+    {
+        var fakeService = new CapturingTranscriptionService { Result = "unused" };
+        var engine = CreateEngine(fakeService);
+        var model = CreateLocalModel();
+
+        await engine.StartRecordingAsync(model);
+        // No Task.Delay — duration is well under MinRecordingSeconds (0.5s),
+        // so the short-recording branch fires and TranscribeAsync is never called.
+        await engine.StopAndTranscribeAsync();
+
+        fakeService.CapturedPath.Should().BeNull(
+            "short-recording branch must not invoke the pipeline");
+
+        // Since we cannot capture the path through the service, diff the
+        // Recordings directory to confirm no rec_*.wav file leaked.
+        var filesAfter = Directory.GetFiles(_recordingsDir, "rec_*.wav").ToHashSet();
+        var newFiles = filesAfter.Except(_preExistingFiles).ToList();
+        foreach (var p in newFiles) _touchedPaths.Add(p);
+
+        newFiles.Should().BeEmpty(
+            "engine must delete the WAV immediately on the short-recording path");
+    }
+
+    // ── Engine construction helper ────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a real <see cref="VoxScriptEngine"/> wired to a real
+    /// <see cref="TranscriptionPipeline"/> and <see cref="TranscriptionServiceRegistry"/>,
+    /// substituting only interfaces. Mirrors the pattern in
+    /// <c>VoxScriptEngineTests.CreateEngine()</c> because
+    /// <see cref="TranscriptionServiceRegistry"/>, <see cref="TranscriptionPipeline"/>,
+    /// <see cref="WordReplacementService"/>, and <see cref="PowerModeSessionManager"/>
+    /// are all sealed and cannot be mocked by NSubstitute.
+    /// </summary>
+    private VoxScriptEngine CreateEngine(ITranscriptionService fakeService)
+    {
+        var audio = Substitute.For<IAudioCaptureService>();
+
+        // Registry with our fake file-based service registered for ModelProvider.Local.
+        var registry = new TranscriptionServiceRegistry([fakeService], []);
+
+        var wordReplacement = new WordReplacementService(
+            Substitute.For<IWordReplacementRepository>(),
+            Substitute.For<IVocabularyRepository>(),
+            Substitute.For<ICommonWordList>());
+
+        var powerModeManager = new PowerModeManager();
+        var powerModeSession = new PowerModeSessionManager(
+            powerModeManager,
+            Substitute.For<IActiveWindowService>());
+
+        var settings = new AppSettings(new InMemorySettingsStore());
+
+        var pipeline = new TranscriptionPipeline(
+            new TranscriptionOutputFilter(),
+            new SmartTextFormatter(),
+            wordReplacement,
+            Substitute.For<VoxScript.Core.AI.IAIEnhancementService>(),
+            Substitute.For<VoxScript.Core.History.ITranscriptionRepository>(),
+            powerModeSession,
+            Substitute.For<IAutoVocabularyService>(),
+            settings,
+            Substitute.For<VoxScript.Core.AI.IStructuralFormattingService>());
+
+        var paste = Substitute.For<IPasteService>();
+        var sounds = Substitute.For<ISoundEffectsService>();
+        var media = Substitute.For<IMediaControlService>();
+
+        return new VoxScriptEngine(audio, registry, pipeline, settings, paste, sounds, media);
+    }
+
+    private static TranscriptionModel CreateLocalModel() => new(
+        Provider: ModelProvider.Local,
+        Name: "test-model",
+        DisplayName: "Test Model",
+        SupportsStreaming: false,   // Forces registry to wrap in FileTranscriptionSession.
+        IsLocal: true);
+
+    // ── Disposable cleanup ────────────────────────────────────────────────
+
+    public void Dispose()
+    {
+        // Clean up any WAV files the engine may have left behind on test failure.
+        foreach (var p in _touchedPaths)
+        {
+            try { if (File.Exists(p)) File.Delete(p); } catch { /* best-effort */ }
+        }
+
+        // Also sweep the Recordings dir for any rec_*.wav files that appeared
+        // during the test and are not in the pre-existing set (defensive — the
+        // short-recording test could fail before we appended to _touchedPaths).
+        try
+        {
+            foreach (var p in Directory.GetFiles(_recordingsDir, "rec_*.wav"))
+            {
+                if (_preExistingFiles.Contains(p)) continue;
+                try { File.Delete(p); } catch { /* best-effort */ }
+            }
+        }
+        catch { /* directory may not exist in degenerate cases */ }
+    }
+
+    // ── Test doubles ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Fake <see cref="ITranscriptionService"/> that captures the audio path
+    /// passed to <see cref="TranscribeAsync"/> and either returns
+    /// <see cref="Result"/> or invokes <see cref="Throw"/> to simulate failure.
+    /// </summary>
+    private sealed class CapturingTranscriptionService : ITranscriptionService
+    {
+        public ModelProvider Provider => ModelProvider.Local;
+        public string? CapturedPath { get; private set; }
+        public string Result { get; set; } = string.Empty;
+        public Action? Throw { get; set; }
+
+        public Task<string> TranscribeAsync(
+            string audioPath, ITranscriptionModel model, string? language, CancellationToken ct)
+        {
+            CapturedPath = audioPath;
+            Throw?.Invoke();
+            return Task.FromResult(Result);
+        }
+    }
+
+    /// <summary>Minimal in-memory <see cref="ISettingsStore"/> for tests.</summary>
+    private sealed class InMemorySettingsStore : ISettingsStore
+    {
+        private readonly Dictionary<string, object?> _data = new();
+        public T? Get<T>(string key) => _data.TryGetValue(key, out var v) ? (T?)v : default;
+        public void Set<T>(string key, T value) => _data[key] = value;
+        public bool Contains(string key) => _data.ContainsKey(key);
+        public void Remove(string key) => _data.Remove(key);
+    }
+}

--- a/VoxScript.Tests/Transcription/VoxScriptEngineWavCleanupTests.cs
+++ b/VoxScript.Tests/Transcription/VoxScriptEngineWavCleanupTests.cs
@@ -22,10 +22,6 @@ public class VoxScriptEngineWavCleanupTests : IDisposable
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "VoxScript", "Recordings");
 
-    // Paths the engine used during the test — tracked so Dispose can clean up
-    // leftover files if an assertion fails before the engine deletes them.
-    private readonly List<string> _touchedPaths = new();
-
     // Files that existed in the Recordings directory before the test ran, so
     // the short-recording test can diff before/after to detect leaked WAVs.
     private readonly HashSet<string> _preExistingFiles;
@@ -51,7 +47,6 @@ public class VoxScriptEngineWavCleanupTests : IDisposable
 
         fakeService.CapturedPath.Should().NotBeNull(
             "engine must have reached the pipeline and invoked TranscribeAsync");
-        _touchedPaths.Add(fakeService.CapturedPath!);
 
         File.Exists(fakeService.CapturedPath!).Should().BeFalse(
             "engine must delete the WAV file after the pipeline completes");
@@ -64,7 +59,7 @@ public class VoxScriptEngineWavCleanupTests : IDisposable
     {
         var fakeService = new CapturingTranscriptionService
         {
-            Throw = () => throw new InvalidOperationException("transcription backend down"),
+            ThrowOnCall = new InvalidOperationException("transcription backend unavailable"),
         };
         var engine = CreateEngine(fakeService);
         var model = CreateLocalModel();
@@ -78,7 +73,6 @@ public class VoxScriptEngineWavCleanupTests : IDisposable
 
         fakeService.CapturedPath.Should().NotBeNull(
             "TranscribeAsync must have been invoked and captured the path before throwing");
-        _touchedPaths.Add(fakeService.CapturedPath!);
 
         File.Exists(fakeService.CapturedPath!).Should().BeFalse(
             "engine must delete the WAV even when the pipeline throws");
@@ -94,6 +88,14 @@ public class VoxScriptEngineWavCleanupTests : IDisposable
         var model = CreateLocalModel();
 
         await engine.StartRecordingAsync(model);
+
+        // Snapshot files right after Start so we have tighter evidence that the
+        // engine both created the WAV and deleted it on the short-recording path.
+        var filesDuringRecording = Directory.GetFiles(_recordingsDir, "rec_*.wav");
+        filesDuringRecording.Length.Should().Be(
+            _preExistingFiles.Count + 1,
+            "StartRecordingAsync must open a new rec_*.wav file");
+
         // No Task.Delay — duration is well under MinRecordingSeconds (0.5s),
         // so the short-recording branch fires and TranscribeAsync is never called.
         await engine.StopAndTranscribeAsync();
@@ -105,7 +107,6 @@ public class VoxScriptEngineWavCleanupTests : IDisposable
         // Recordings directory to confirm no rec_*.wav file leaked.
         var filesAfter = Directory.GetFiles(_recordingsDir, "rec_*.wav").ToHashSet();
         var newFiles = filesAfter.Except(_preExistingFiles).ToList();
-        foreach (var p in newFiles) _touchedPaths.Add(p);
 
         newFiles.Should().BeEmpty(
             "engine must delete the WAV immediately on the short-recording path");
@@ -113,15 +114,8 @@ public class VoxScriptEngineWavCleanupTests : IDisposable
 
     // ── Engine construction helper ────────────────────────────────────────
 
-    /// <summary>
-    /// Builds a real <see cref="VoxScriptEngine"/> wired to a real
-    /// <see cref="TranscriptionPipeline"/> and <see cref="TranscriptionServiceRegistry"/>,
-    /// substituting only interfaces. Mirrors the pattern in
-    /// <c>VoxScriptEngineTests.CreateEngine()</c> because
-    /// <see cref="TranscriptionServiceRegistry"/>, <see cref="TranscriptionPipeline"/>,
-    /// <see cref="WordReplacementService"/>, and <see cref="PowerModeSessionManager"/>
-    /// are all sealed and cannot be mocked by NSubstitute.
-    /// </summary>
+    // Builds a real VoxScriptEngine; mirrors VoxScriptEngineTests.CreateEngine() because
+    // the registry/pipeline/word-replacement/power-mode types are sealed.
     private VoxScriptEngine CreateEngine(ITranscriptionService fakeService)
     {
         var audio = Substitute.For<IAudioCaptureService>();
@@ -170,50 +164,33 @@ public class VoxScriptEngineWavCleanupTests : IDisposable
 
     public void Dispose()
     {
-        // Clean up any WAV files the engine may have left behind on test failure.
-        foreach (var p in _touchedPaths)
+        // Sweep the Recordings dir for any rec_*.wav files that appeared
+        // during the test and are not in the pre-existing set.
+        foreach (var p in Directory.GetFiles(_recordingsDir, "rec_*.wav"))
         {
-            try { if (File.Exists(p)) File.Delete(p); } catch { /* best-effort */ }
+            if (_preExistingFiles.Contains(p)) continue;
+            try { File.Delete(p); } catch { /* best-effort */ }
         }
-
-        // Also sweep the Recordings dir for any rec_*.wav files that appeared
-        // during the test and are not in the pre-existing set (defensive — the
-        // short-recording test could fail before we appended to _touchedPaths).
-        try
-        {
-            foreach (var p in Directory.GetFiles(_recordingsDir, "rec_*.wav"))
-            {
-                if (_preExistingFiles.Contains(p)) continue;
-                try { File.Delete(p); } catch { /* best-effort */ }
-            }
-        }
-        catch { /* directory may not exist in degenerate cases */ }
     }
 
     // ── Test doubles ──────────────────────────────────────────────────────
 
-    /// <summary>
-    /// Fake <see cref="ITranscriptionService"/> that captures the audio path
-    /// passed to <see cref="TranscribeAsync"/> and either returns
-    /// <see cref="Result"/> or invokes <see cref="Throw"/> to simulate failure.
-    /// </summary>
     private sealed class CapturingTranscriptionService : ITranscriptionService
     {
         public ModelProvider Provider => ModelProvider.Local;
         public string? CapturedPath { get; private set; }
         public string Result { get; set; } = string.Empty;
-        public Action? Throw { get; set; }
+        public Exception? ThrowOnCall { get; set; }
 
         public Task<string> TranscribeAsync(
             string audioPath, ITranscriptionModel model, string? language, CancellationToken ct)
         {
             CapturedPath = audioPath;
-            Throw?.Invoke();
+            if (ThrowOnCall is not null) throw ThrowOnCall;
             return Task.FromResult(Result);
         }
     }
 
-    /// <summary>Minimal in-memory <see cref="ISettingsStore"/> for tests.</summary>
     private sealed class InMemorySettingsStore : ISettingsStore
     {
         private readonly Dictionary<string, object?> _data = new();


### PR DESCRIPTION
## Summary

Every recording today writes a WAV to `%LocalAppData%\VoxScript\Recordings\` and the file is never deleted. Nothing in the app reads those files after the initial transcription step — `TranscriptionRecord.AudioFilePath` was stored on every record but never consumed by any UI or service. The folder grows unbounded.

This PR deletes the WAV as soon as the recording lifecycle ends, and removes the now-meaningless DB column.

## Changes

- **`DeleteWavFile()` helper** on `VoxScriptEngine` — null-guarded, catches only `IOException` and `UnauthorizedAccessException`, logs at warning level, nulls `_currentAudioPath` in `finally`.
- **Cleanup wired into every recording-lifecycle exit path:**
  - Normal pipeline completion — `try/finally` in `StopAndTranscribeAsync`, so both success and pipeline-throw cases are covered.
  - Short-recording early return (`duration < MinRecordingSeconds`).
  - Startup failure — `StartRecordingAsync` catch block (partial WAV was being orphaned).
  - Cancel — `CancelRecordingAsync` was also leaking the WAV and the `FileStream` handle; now disposes and deletes. Caught during review; not in the original spec enumeration but covered by its stated goal.
- **Stop writing `AudioFilePath`** on `TranscriptionRecord` in `TranscriptionPipeline`.
- **Remove `AudioFilePath` property** from `TranscriptionRecord`.
- **EF Core migration `DropAudioFilePath`** with matching `Up`/`Down` (drops nullable TEXT column, reversible).

## Safety: why the delete can't race with in-flight reads

`DeleteWavFile()` runs after `await _pipeline.RunAsync(...)` returns. The pipeline's first step awaits `session.TranscribeAsync(audioFilePath, ct)`. Every current batch service (`LocalTranscriptionService`, `ParakeetTranscriptionService`, `OpenAICompatibleTranscriptionService`, `CloudTranscriptionService`) fully consumes the file before returning — either `Task.Run(() => ReadWavAsFloat(...))` or `await using var audioStream = File.OpenRead(...)` with `await`ed upload. Streaming sessions never write the file. No file handle is open past pipeline completion.

## Tests

New `VoxScriptEngineWavCleanupTests.cs` covers three lifecycle paths:
- Success: WAV deleted after normal transcription.
- Failure: WAV deleted when the pipeline throws (finally still runs).
- Short-recording: WAV created then deleted without transcription.

Full solution build: 0 warnings, 0 errors. Full test suite: 328 passing.

## Out of scope

- No cleanup of existing accumulated `rec_*.wav` files — users clear manually.
- No opt-in "keep audio" setting.
- Four test-infrastructure follow-ups filed at #8 (injectable recordings root, shared test helper extraction, `TimeProvider` seam, additional exit-path tests).

## Test plan

- [x] Full solution build clean
- [x] Full test suite passes (328/328)
- [x] New lifecycle tests pass (3/3)
- [x] EF migration Up/Down inspected
- [x] Manual smoke: record a few clips locally, verify `%LocalAppData%\VoxScript\Recordings\` stays empty after each