### PR TITLE
fix(tray): sync microphone submenu with settings and device changes

### DIFF
--- a/VoxScript.Core/Audio/IAudioCaptureService.cs
+++ b/VoxScript.Core/Audio/IAudioCaptureService.cs
@@ -8,5 +8,11 @@ public interface IAudioCaptureService
     Task StartAsync(string? deviceId, Action<byte[], int> onChunk, CancellationToken ct);
     Task StopAsync();
 
-    event EventHandler<AudioDeviceInfo>? DeviceChanged;
+    /// <summary>
+    /// Raised when the set of capture endpoints or the system default
+    /// changes (device added/removed, default reassigned, state toggled).
+    /// Fired on a WASAPI notification thread — subscribers must marshal
+    /// to the UI thread before touching UI state.
+    /// </summary>
+    event EventHandler? DevicesChanged;
 }

--- a/VoxScript.Core/Settings/AppSettings.cs
+++ b/VoxScript.Core/Settings/AppSettings.cs
@@ -16,8 +16,20 @@ public sealed class AppSettings
     public string? AudioDeviceId
     {
         get => _store.Get<string>(nameof(AudioDeviceId));
-        set => _store.Set(nameof(AudioDeviceId), value);
+        set
+        {
+            _store.Set(nameof(AudioDeviceId), value);
+            AudioDeviceIdChanged?.Invoke(this, value);
+        }
     }
+
+    /// <summary>
+    /// Raised whenever <see cref="AudioDeviceId"/> is written, so every
+    /// surface that shows the current mic (settings page, tray menu, etc.)
+    /// can stay in sync regardless of which one initiated the change.
+    /// Invoked on the same thread that performed the write.
+    /// </summary>
+    public event EventHandler<string?>? AudioDeviceIdChanged;
 
     public string? TranscriptionLanguage
     {

--- a/VoxScript.Native/Audio/WasapiCaptureService.cs
+++ b/VoxScript.Native/Audio/WasapiCaptureService.cs
@@ -1,5 +1,6 @@
 // VoxScript.Native/Audio/WasapiCaptureService.cs
 using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
 using NAudio.Wave;
 using VoxScript.Core.Audio;
 
@@ -7,19 +8,26 @@ namespace VoxScript.Native.Audio;
 
 public sealed class WasapiCaptureService : IAudioCaptureService, IDisposable
 {
+    private readonly MMDeviceEnumerator _enumerator = new();
+    private readonly DeviceChangeNotificationClient _notificationClient;
     private WasapiCapture? _capture;
     private Action<byte[], int>? _onChunk;
     private CancellationToken _ct;
     private bool _disposed;
+
+    public WasapiCaptureService()
+    {
+        _notificationClient = new DeviceChangeNotificationClient(
+            () => DevicesChanged?.Invoke(this, EventArgs.Empty));
+        _enumerator.RegisterEndpointNotificationCallback(_notificationClient);
+    }
 
     public IReadOnlyList<AudioDeviceInfo> EnumerateDevices() =>
         AudioDeviceEnumerator.EnumerateCapture();
 
     public AudioDeviceInfo? DefaultDevice => AudioDeviceEnumerator.GetDefault();
 
-#pragma warning disable CS0067 // Required by IAudioCaptureService, raised when device detection is implemented
-    public event EventHandler<AudioDeviceInfo>? DeviceChanged;
-#pragma warning restore CS0067
+    public event EventHandler? DevicesChanged;
 
     public Task StartAsync(string? deviceId, Action<byte[], int> onChunk, CancellationToken ct)
     {
@@ -69,10 +77,42 @@ public sealed class WasapiCaptureService : IAudioCaptureService, IDisposable
 
     public void Dispose()
     {
-        if (!_disposed)
+        if (_disposed) return;
+        try
         {
-            _capture?.Dispose();
-            _disposed = true;
+            _enumerator.UnregisterEndpointNotificationCallback(_notificationClient);
         }
+        catch
+        {
+            // Swallow: registration/unregistration can throw during shutdown
+            // if the COM apartment is already torn down, and leaking the
+            // registration briefly is benign compared to crashing exit.
+        }
+        _capture?.Dispose();
+        _enumerator.Dispose();
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// IMMNotificationClient that forwards every WASAPI endpoint event to a
+    /// single "something changed" callback. We don't distinguish between
+    /// add/remove/default-change because every consumer today just wants to
+    /// re-enumerate. Callbacks fire on a WASAPI MTA thread.
+    /// </summary>
+    private sealed class DeviceChangeNotificationClient : IMMNotificationClient
+    {
+        private readonly Action _onChange;
+
+        public DeviceChangeNotificationClient(Action onChange) => _onChange = onChange;
+
+        public void OnDeviceStateChanged(string deviceId, DeviceState newState) => _onChange();
+        public void OnDeviceAdded(string pwstrDeviceId) => _onChange();
+        public void OnDeviceRemoved(string deviceId) => _onChange();
+        public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId) => _onChange();
+
+        // Property changes fire rapidly (volume, format, etc.) and never
+        // affect the device list we care about, so we deliberately ignore
+        // them to avoid rebuilding the tray menu dozens of times per second.
+        public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) { }
     }
 }

--- a/VoxScript/Shell/SystemTrayManager.cs
+++ b/VoxScript/Shell/SystemTrayManager.cs
@@ -15,6 +15,9 @@ namespace VoxScript.Shell;
 public sealed class SystemTrayManager : IDisposable
 {
     private TaskbarIcon? _trayIcon;
+    private MenuFlyoutSubItem? _micSub;
+    private IAudioCaptureService? _audioService;
+    private AppSettings? _settings;
     private readonly VoxScriptEngine _engine;
     private readonly Window _mainWindow;
 
@@ -69,6 +72,25 @@ public sealed class SystemTrayManager : IDisposable
 
         // Right-click context menu
         _trayIcon.ContextFlyout = BuildContextMenu();
+
+        // H.NotifyIcon SecondWindow mode reparents our items into a separately
+        // constructed MenuFlyout ONCE (in PrepareContextMenuWindow), so the
+        // source MenuFlyout.Opening event we'd normally hook never fires and
+        // the version of H.NotifyIcon we ship with (2.4.1) doesn't expose an
+        // equivalent "about to show" event. Instead of waiting for a menu-open
+        // signal, we push-update the mic list whenever WASAPI reports a device
+        // change. The MenuFlyoutSubItem reference survives reparenting, so
+        // mutating `_micSub.Items` still updates what the user sees next time
+        // they open the tray menu.
+        _audioService = ServiceLocator.Get<IAudioCaptureService>();
+        _audioService.DevicesChanged += OnAudioDevicesChanged;
+
+        // Keep the tray's radio selection in sync with whoever else writes to
+        // AudioDeviceId (settings page, onboarding, future surfaces). The
+        // setter raises this on the writer's thread; rebuild is queued to the
+        // UI thread either way.
+        _settings = ServiceLocator.Get<AppSettings>();
+        _settings.AudioDeviceIdChanged += OnAudioDeviceIdChanged;
 
         // Left-click opens the window
         _trayIcon.LeftClickCommand = new RelayCommand(() =>
@@ -138,43 +160,13 @@ public sealed class SystemTrayManager : IDisposable
 
         menu.Items.Add(new MenuFlyoutSeparator());
 
-        // Microphone submenu
-        var micSub = new MenuFlyoutSubItem { Text = "Microphone", MinWidth = MenuItemMinWidth };
-        try
-        {
-            var audio = ServiceLocator.Get<IAudioCaptureService>();
-            var settings = ServiceLocator.Get<AppSettings>();
-            var devices = audio.EnumerateDevices();
-            var selectedId = settings.AudioDeviceId;
-
-            foreach (var device in devices)
-            {
-                var item = new ToggleMenuFlyoutItem { Text = device.DisplayName };
-
-                // Check the currently selected device (null = system default)
-                var isSelected = selectedId is null
-                    ? device.IsDefault
-                    : device.Id == selectedId;
-                item.IsChecked = isSelected;
-
-                var capturedDevice = device;
-                item.Click += (_, _) =>
-                {
-                    // null means "use system default"
-                    settings.AudioDeviceId = capturedDevice.IsDefault ? null : capturedDevice.Id;
-                    Serilog.Log.Information("Microphone changed via tray: {Device}", capturedDevice.DisplayName);
-                };
-
-                micSub.Items.Add(item);
-            }
-        }
-        catch (Exception ex)
-        {
-            Serilog.Log.Warning(ex, "Failed to enumerate microphones for tray menu");
-            var errorItem = new MenuFlyoutItem { Text = "No devices found", IsEnabled = false };
-            micSub.Items.Add(errorItem);
-        }
-        menu.Items.Add(micSub);
+        // Microphone submenu. Populated once here so items exist when
+        // H.NotifyIcon reparents them into its SecondWindow flyout at init
+        // time; refreshed on every right-click via SecondWindowContextMenuOpened
+        // so mics plugged in after launch show up without restarting the app.
+        _micSub = new MenuFlyoutSubItem { Text = "Microphone", MinWidth = MenuItemMinWidth };
+        PopulateMicrophoneSubMenu(_micSub);
+        menu.Items.Add(_micSub);
 
         // Settings
         var settingsItem = new MenuFlyoutItem { Text = "Settings", MinWidth = MenuItemMinWidth };
@@ -209,6 +201,114 @@ public sealed class SystemTrayManager : IDisposable
         return menu;
     }
 
+    // Shared GroupName so WinUI's RadioMenuFlyoutItem coordination auto-
+    // unchecks the previously-selected mic when the user picks a new one
+    // (ToggleMenuFlyoutItem gave checkbox semantics, letting several stay
+    // checked at once).
+    private const string MicRadioGroupName = "TrayMicrophone";
+
+    private static void PopulateMicrophoneSubMenu(MenuFlyoutSubItem micSub)
+    {
+        micSub.Items.Clear();
+        try
+        {
+            var audio = ServiceLocator.Get<IAudioCaptureService>();
+            var settings = ServiceLocator.Get<AppSettings>();
+            var devices = audio.EnumerateDevices();
+            var selectedId = settings.AudioDeviceId;
+
+            // "System default" entry mirrors the Settings page so auto-detect
+            // is always representable, even when the current default device
+            // is unplugged.
+            AddMicRadioItem(
+                micSub,
+                text: "System default (auto-detect)",
+                isChecked: selectedId is null,
+                onPicked: () =>
+                {
+                    settings.AudioDeviceId = null;
+                    Serilog.Log.Information("Microphone changed via tray: System default");
+                });
+
+            foreach (var device in devices)
+            {
+                var capturedDevice = device;
+                AddMicRadioItem(
+                    micSub,
+                    text: device.DisplayName,
+                    isChecked: selectedId is not null && device.Id == selectedId,
+                    onPicked: () =>
+                    {
+                        settings.AudioDeviceId = capturedDevice.Id;
+                        Serilog.Log.Information("Microphone changed via tray: {Device}", capturedDevice.DisplayName);
+                    });
+            }
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Warning(ex, "Failed to enumerate microphones for tray menu");
+            var errorItem = new MenuFlyoutItem { Text = "No devices found", IsEnabled = false };
+            micSub.Items.Add(errorItem);
+        }
+    }
+
+    private static void AddMicRadioItem(
+        MenuFlyoutSubItem micSub,
+        string text,
+        bool isChecked,
+        Action onPicked)
+    {
+        var item = new RadioMenuFlyoutItem
+        {
+            Text = text,
+            GroupName = MicRadioGroupName,
+            IsChecked = isChecked,
+        };
+        micSub.Items.Add(item);
+
+        // Click is the primary signal, but MenuFlyoutSubItem children under
+        // H.NotifyIcon's SecondWindow host have been observed to swallow Click
+        // in some configurations while still toggling IsChecked. Listening to
+        // IsChecked directly is a resilient fallback that also picks up
+        // selections driven by the group-name coordination itself.
+        // Registered after setting IsChecked above so the initial state
+        // assignment doesn't re-fire onPicked.
+        item.Click += (_, _) =>
+        {
+            if (item.IsChecked) onPicked();
+        };
+        item.RegisterPropertyChangedCallback(
+            RadioMenuFlyoutItem.IsCheckedProperty,
+            (_, _) =>
+            {
+                if (item.IsChecked) onPicked();
+            });
+    }
+
+    private void OnAudioDevicesChanged(object? sender, EventArgs e)
+    {
+        // Fires on a WASAPI notification thread — marshal to the UI thread
+        // before touching MenuFlyoutSubItem.Items (XAML requires UI-thread
+        // affinity for dependency-object mutations).
+        RefreshMicrophoneSubMenuOnUiThread();
+    }
+
+    private void OnAudioDeviceIdChanged(object? sender, string? newValue)
+    {
+        RefreshMicrophoneSubMenuOnUiThread();
+    }
+
+    private void RefreshMicrophoneSubMenuOnUiThread()
+    {
+        _mainWindow.DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_micSub is not null)
+            {
+                PopulateMicrophoneSubMenu(_micSub);
+            }
+        });
+    }
+
     private void OnEngineStateChanged(object? sender,
         System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -231,6 +331,16 @@ public sealed class SystemTrayManager : IDisposable
 
     public void Dispose()
     {
+        if (_audioService is not null)
+        {
+            _audioService.DevicesChanged -= OnAudioDevicesChanged;
+            _audioService = null;
+        }
+        if (_settings is not null)
+        {
+            _settings.AudioDeviceIdChanged -= OnAudioDeviceIdChanged;
+            _settings = null;
+        }
         _trayIcon?.Dispose();
         _engine.PropertyChanged -= OnEngineStateChanged;
     }

--- a/VoxScript/ViewModels/SettingsViewModel.cs
+++ b/VoxScript/ViewModels/SettingsViewModel.cs
@@ -18,6 +18,14 @@ public sealed partial class SettingsViewModel : ObservableObject
     private readonly IAudioCaptureService _audioService;
     private readonly GlobalHotkeyService _hotkeyService;
     private readonly ApiKeyManager _keyManager;
+    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcher;
+
+    // Prevents the write-back loop when an external AudioDeviceId change
+    // pushes a new SelectedAudioDevice into the combobox: without this, the
+    // partial OnSelectedAudioDeviceChanged would write the same id back to
+    // AppSettings, re-fire AudioDeviceIdChanged, and bounce once before
+    // settling.
+    private bool _syncingAudioDeviceFromExternal;
 
     public SettingsViewModel()
     {
@@ -26,8 +34,70 @@ public sealed partial class SettingsViewModel : ObservableObject
         _hotkeyService = ServiceLocator.Get<GlobalHotkeyService>();
         _keyManager = ServiceLocator.Get<ApiKeyManager>();
 
+        // Captured now so the WASAPI notification thread (which raises
+        // DevicesChanged) can marshal back to the UI thread — the VM is
+        // always constructed on the UI thread during page navigation.
+        _dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+
         LoadAudioDevices();
         LoadSettings();
+
+        // Subscribe AFTER initial load so the direct assignments in
+        // LoadSettings don't double through the handlers.
+        _settings.AudioDeviceIdChanged += OnExternalAudioDeviceIdChanged;
+        _audioService.DevicesChanged += OnExternalDevicesChanged;
+    }
+
+    /// <summary>
+    /// Unsubscribes from external change events. Must be called when the
+    /// page is being torn down, otherwise the singleton AppSettings /
+    /// IAudioCaptureService instances keep every orphaned VM alive.
+    /// SettingsPage wires this to Page.Unloaded.
+    /// </summary>
+    public void Cleanup()
+    {
+        _settings.AudioDeviceIdChanged -= OnExternalAudioDeviceIdChanged;
+        _audioService.DevicesChanged -= OnExternalDevicesChanged;
+    }
+
+    private void OnExternalAudioDeviceIdChanged(object? sender, string? newId)
+    {
+        // Marshal defensively: every writer today is UI-thread, but this
+        // event only guarantees "whatever thread wrote AudioDeviceId".
+        _dispatcher?.TryEnqueue(() => SyncSelectedAudioDevice(newId));
+    }
+
+    private void OnExternalDevicesChanged(object? sender, EventArgs e)
+    {
+        // WASAPI fires this on an MTA notification thread — ObservableCollection
+        // mutations and ObservableProperty writes must happen on the UI thread.
+        _dispatcher?.TryEnqueue(() =>
+        {
+            LoadAudioDevices();
+            // Preserve the persisted selection, re-resolved against the new
+            // device list (in case the selected device was just removed).
+            SyncSelectedAudioDevice(_settings.AudioDeviceId);
+        });
+    }
+
+    private void SyncSelectedAudioDevice(string? deviceId)
+    {
+        var match = deviceId is null
+            ? AudioDevices.FirstOrDefault(d => d.IsDefault)
+            : AudioDevices.FirstOrDefault(d => d.Id == deviceId)
+              ?? AudioDevices.FirstOrDefault(d => d.IsDefault);
+
+        if (ReferenceEquals(match, SelectedAudioDevice)) return;
+
+        _syncingAudioDeviceFromExternal = true;
+        try
+        {
+            SelectedAudioDevice = match;
+        }
+        finally
+        {
+            _syncingAudioDeviceFromExternal = false;
+        }
     }
 
     // ── Current Model ─────────────────────────────────────────
@@ -293,6 +363,7 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnSelectedAudioDeviceChanged(AudioDeviceDisplay? value)
     {
+        if (_syncingAudioDeviceFromExternal) return;
         if (value is null) return;
         _settings.AudioDeviceId = value.IsDefault ? null : value.Id;
     }

--- a/VoxScript/Views/SettingsPage.xaml.cs
+++ b/VoxScript/Views/SettingsPage.xaml.cs
@@ -17,6 +17,12 @@ public sealed partial class SettingsPage : Page
     {
         ViewModel = new SettingsViewModel();
         this.InitializeComponent();
+
+        // Unsubscribe the VM from AppSettings / IAudioCaptureService when the
+        // page leaves the visual tree. Those are singletons, so a missed
+        // unsubscribe would keep every navigated-away VM rooted in memory
+        // for the life of the process.
+        this.Unloaded += (_, _) => ViewModel.Cleanup();
     }
 
     // ── Keybind button click handlers ──────────────────────────


### PR DESCRIPTION
## Summary

Fixes #10. The tray Microphone submenu had three bugs stacked on top of each other, which the single-origin report ("only one option, and it doesn't update") masked:

- **Stale list.** Submenu was built once at launch and never refreshed, so mics plugged in after startup never appeared.
- **Broken selection.** `ToggleMenuFlyoutItem` gave checkbox semantics, so multiple items could stay checked at once, and Click wasn't firing reliably for submenu children under H.NotifyIcon's `SecondWindow` host — so the selection didn't persist.
- **One-way sync.** Settings page and tray didn't observe each other's writes to `AppSettings.AudioDeviceId`, and the Settings page also didn't observe device hardware changes while open.

## Changes

- **`SystemTrayManager`**: `RadioMenuFlyoutItem` with a shared `GroupName` for exclusive selection; `IsChecked` property-changed callback alongside `Click` as a resilient fallback; `MenuFlyoutSubItem` kept as a field so mutations to `Items` land in the displayed flyout even after H.NotifyIcon reparents our items into its secondary window.
- **`WasapiCaptureService`**: `IMMNotificationClient` registered via `MMDeviceEnumerator.RegisterEndpointNotificationCallback`, forwards WASAPI add/remove/default-change/state-change events into the renamed `IAudioCaptureService.DevicesChanged`. Ignores the (noisy) `OnPropertyValueChanged`.
- **`AppSettings`**: new `AudioDeviceIdChanged` event raised from the setter (same pattern as the existing `RecordingIndicatorModeChanged`) so every writer keeps bound UIs in sync.
- **`SettingsViewModel`**: subscribes to both `AudioDeviceIdChanged` and `DevicesChanged`, re-resolves `SelectedAudioDevice` against the live device list on each change, guards against the combobox-setter write-back loop with a flag. `Cleanup()` unsubscribes; `SettingsPage.Unloaded` calls it so singleton event sources don't root every navigated-away VM.

All three fixes are load-bearing — dropping any one of them re-introduces a user-visible bug from #10.

## Test plan

- [x] Launch app with one mic connected → right-click tray → Microphone submenu shows "System default (auto-detect)" + the one mic, correct radio dot.
- [x] Plug in a second mic while app is running → right-click tray → new mic appears without restart.
- [x] Unplug the currently-selected mic → tray list updates; if it was set explicitly, selection falls back to System default.
- [x] Click a mic in the tray → only that one keeps the radio dot; `%LOCALAPPDATA%\VoxScript\settings.json` reflects the new `AudioDeviceId` (or `null` for default); next recording uses it.
- [x] Open Settings, change mic in the combobox → right-click tray → radio dot on same mic.
- [x] With Settings already open, change mic from tray → combobox in Settings updates live (no navigation needed).
- [x] With Settings already open, plug in a new mic → it appears in the Settings combobox list live.
- [x] `dotnet test VoxScript.Tests` all pass.